### PR TITLE
Support Strapi ~v4.19.0

### DIFF
--- a/admin/src/components/FieldsCheckbox/index.js
+++ b/admin/src/components/FieldsCheckbox/index.js
@@ -1,13 +1,13 @@
-import { BaseCheckbox } from "@strapi/design-system/BaseCheckbox";
 import React, { useState, useEffect } from "react";
 import { Box } from "@strapi/design-system/Box";
+import { Checkbox } from "@strapi/design-system/Checkbox";
 
 export function FieldsCheckbox({ table, field, toggleSelectedOfField }) {
   const [val, setValue] = useState(field.selected);
 
   return (
     <Box>
-      <BaseCheckbox
+      <Checkbox
         aria-label="fields checkbox"
         name={`base-checkbox-${table}-${field.name}`}
         id={`base-checkbox-${table}-${field.name}`}
@@ -17,13 +17,9 @@ export function FieldsCheckbox({ table, field, toggleSelectedOfField }) {
         }}
         value={val}
         disabled={field.name === "id"}
-      />
-      <label
-        style={{ marginLeft: 5 }}
-        htmlFor={`base-checkbox-${table}-${field.name}`}
       >
         {field.name}
-      </label>
+      </Checkbox>
     </Box>
   );
 }

--- a/admin/src/pages/CustomAPICustomizationPage/index.js
+++ b/admin/src/pages/CustomAPICustomizationPage/index.js
@@ -41,16 +41,18 @@ const CustomAPICustomizationPage = ({
  */
   const [contentTypes, setContentTypes] = useState(null);
 
-  useEffect(async () => {
-    const contentTypeDataRaw = await customApiRequest.getAllContentTypes();
-    const contentTypeMetadata = contentTypeDataRaw.map((item) => {
-      return {
-        uid: item.uid,
-        displayName: item.info.displayName,
-      };
-    });
+  useEffect(() => {
+    (async () => {
+      const contentTypeDataRaw = await customApiRequest.getAllContentTypes();
+      const contentTypeMetadata = contentTypeDataRaw.map((item) => {
+        return {
+          uid: item.uid,
+          displayName: item.info.displayName,
+        };
+      });
 
-    setContentTypes(contentTypeMetadata);
+      setContentTypes(contentTypeMetadata);
+    })()
   }, []);
 
   /**
@@ -70,52 +72,58 @@ const CustomAPICustomizationPage = ({
   // 2. setting slug
   // 3. setting selected content type
   // 4. setting the selectable data
-  useEffect(async () => {
-    if (!showCustomAPICustomizationPage || !showCustomAPICustomizationPage.id)
-      return;
+  useEffect(() => {
+    (async () => {
+      if (!showCustomAPICustomizationPage || !showCustomAPICustomizationPage.id)
+        return;
 
-    // edit mode
-    const editModeData = await customApiRequest.getCustomApiById(
-      showCustomAPICustomizationPage.id
-    );
-
-    if (editModeData) {
       // edit mode
-      setName(editModeData.name);
-      setSlug(editModeData.slug);
-      setSelectedContentType(editModeData.selectedContentType);
-      setSelectableData(editModeData.structure);
-    }
+      const editModeData = await customApiRequest.getCustomApiById(
+        showCustomAPICustomizationPage.id
+      );
+
+      if (editModeData) {
+        // edit mode
+        setName(editModeData.name);
+        setSlug(editModeData.slug);
+        setSelectedContentType(editModeData.selectedContentType);
+        setSelectableData(editModeData.structure);
+      }
+    })()
   }, []);
 
   // side effects for the create mode
   // 1. setting selectableData
   // 2. name, slug & selectedContentType empty/default state.
-  useEffect(async () => {
-    if (showCustomAPICustomizationPage && showCustomAPICustomizationPage.id)
-      return;
+  useEffect(() => {
+    (async () => {
+      if (showCustomAPICustomizationPage && showCustomAPICustomizationPage.id)
+        return;
 
-    if (!selectedContentType) return;
+      if (!selectedContentType) return;
 
-    // create mode
-    const selectedContentTypeRaw = await fetchContentTypeData({
-      uid: selectedContentType.uid,
-    });
+      // create mode
+      const selectedContentTypeRaw = await fetchContentTypeData({
+        uid: selectedContentType.uid,
+      });
 
-    if (!selectedContentTypeRaw) return;
+      if (!selectedContentTypeRaw) return;
 
-    const iteratedUIDs = [];
-    const reducedEntries = {};
+      const iteratedUIDs = [];
+      const reducedEntries = {};
 
-    await getReducedDataObject({
-      currentContentTypeRaw: cloneDeep(selectedContentTypeRaw),
-      iteratedUIDs: iteratedUIDs,
-      reducedEntries: reducedEntries,
-    });
+      console.log(selectedContentTypeRaw);
 
-    if (reducedEntries) {
-      setSelectableData(reducedEntries);
-    }
+      await getReducedDataObject({
+        currentContentTypeRaw: cloneDeep(selectedContentTypeRaw),
+        iteratedUIDs: iteratedUIDs,
+        reducedEntries: reducedEntries,
+      });
+
+      if (reducedEntries) {
+        setSelectableData(reducedEntries);
+      }
+    })()
   }, [selectedContentType]);
 
   function getNewFieldDataWithToggledSelected(entries, tableName, fieldName) {
@@ -300,15 +308,15 @@ const CustomAPICustomizationPage = ({
               value={selectedContentType ? selectedContentType.uid : null}
               disabled={
                 showCustomAPICustomizationPage &&
-                showCustomAPICustomizationPage.id
+                  showCustomAPICustomizationPage.id
                   ? true
                   : false
               }
               onChange={(val) => {
                 setSelectedContentType(
                   contentTypes &&
-                    contentTypes.length &&
-                    contentTypes.filter((item) => item.uid === val)[0]
+                  contentTypes.length &&
+                  contentTypes.filter((item) => item.uid === val)[0]
                 );
               }}
             >

--- a/admin/src/pages/HomePage/index.js
+++ b/admin/src/pages/HomePage/index.js
@@ -37,7 +37,7 @@ const HomePage = () => {
     setIsLoading(false);
   };
 
-  useEffect(async () => {
+  useEffect(() => {
     fetchData();
   }, []);
 
@@ -110,9 +110,8 @@ const HomePage = () => {
               title={upperFirst(
                 `custom  API${customAPIData.length > 1 ? "s" : ""}`
               )}
-              subtitle={`${customAPIData.length} ${
-                customAPIData.length > 1 ? "entries" : "entry"
-              } found`}
+              subtitle={`${customAPIData.length} ${customAPIData.length > 1 ? "entries" : "entry"
+                } found`}
             />
             <ContentLayout>
               <CustomAPITable

--- a/admin/src/utils/customApiBuilderUtils.js
+++ b/admin/src/utils/customApiBuilderUtils.js
@@ -47,12 +47,16 @@ async function getReducedDataObject({
           uid: relationalUid,
         });
 
-        await getReducedDataObject({
-          currentContentTypeRaw: selectedContentTypeRaw,
-          iteratedUIDs: iteratedUIDs,
-          reducedEntries: reducedContentData,
-          currentRelationalField: key,
-        });
+        if (!selectedContentTypeRaw) {
+          console.log(`Could fetch content type data for ${relationalUid}`);
+        } else {
+          await getReducedDataObject({
+            currentContentTypeRaw: selectedContentTypeRaw,
+            iteratedUIDs: iteratedUIDs,
+            reducedEntries: reducedContentData,
+            currentRelationalField: key,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
This removes async methods from useEffects and replaces them with synchronous functions that call an asynchronous method inside. Seems like react doesn't want to deal with Promises properly now? 

Checkboxes replaced with proper strapi checkbox component for theme support.

When fetching using getReducedDataObject fails, the field will be skipped. (Fixes admin::user causing error)

Looks like I included some formatting. Too bad. Also whether the created apis still work actually, is not tested.